### PR TITLE
Ignore old entries during de-duplication, adjust SBC upper cutoff date

### DIFF
--- a/server/lambda/layer/common/nodejs/custom_modules/send-to-sbc.js
+++ b/server/lambda/layer/common/nodejs/custom_modules/send-to-sbc.js
@@ -3,7 +3,7 @@ const asyncPool = require('tiny-async-pool');
 const { postServiceItem } = require('./service-bc-api');
 
 const getUnsuccessfulSbcTransactions = async (collection, arrivalKey) => {
-  const dateRange = [dayjs().subtract(13, 'day'), dayjs().subtract(2, 'day')]
+  const dateRange = [dayjs().subtract(13, 'day'), dayjs().subtract(1, 'day')]
     .map((d) => d.startOf('day').toDate());
   const query = [
     { $addFields: { parsed_arrival_date: { $dateFromString: { dateString: arrivalKey, timezone: '-0700' } } } },

--- a/server/lambda/phacToSbc/mark-duplicates.js
+++ b/server/lambda/phacToSbc/mark-duplicates.js
@@ -140,7 +140,7 @@ const markDuplicates = async (etsCollection, phacCollection) => {
     }, {
       $project: {
         _id: 0,
-        parsed_arrival_date: 0,
+        parsed_arrival_date: 1,
         covid_id: 1,
         arrival_date: 1,
         home_phone: 1,

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -6869,6 +6869,11 @@
         "minimist": "^1.2.5"
       }
     },
+    "mockdate": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mockdate/-/mockdate-3.0.2.tgz",
+      "integrity": "sha512-ldfYSUW1ocqSHGTK6rrODUiqAFPGAg0xaHqYJ5tvj1hQyFsjuHpuWgWFTZWwDVlzougN/s2/mhDr8r5nY5xDpA=="
+    },
     "mongodb": {
       "version": "3.5.6",
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.5.6.tgz",

--- a/server/package.json
+++ b/server/package.json
@@ -38,6 +38,7 @@
     "husky": "4.2.5",
     "jest": "25.3.0",
     "lint-staged": "10.1.4",
+    "mockdate": "3.0.2",
     "nodemon": "2.0.4",
     "supertest": "4.0.2",
     "tiny-async-pool": "1.1.0"

--- a/server/tests/mock/phac-data.csv
+++ b/server/tests/mock/phac-data.csv
@@ -32,5 +32,5 @@ CVR-0159104,Alayne,Looks,2018-02-06,Asymptomatic,2020-05-18,2020-06-01,,673 Ande
 CVR-0159105,Invalid,Isaiah,1979-08-28,Asymptomatic,2020-05-28,2020-06-11,,3043 Veith Alley,Burnaby,G2K2U5,9879879877,,,ddavidson@fakesite.com,Land border,Carson,,,,British Columbia
 CVR-0159106,Adam,Ant,1957-09-23,Asymptomatic,2020-05-18,2020-06-01,,8 Union Circle,Abboisford,I7G8M1,123-123-1234,,,asdf@asdf.c,Land border,Douglas,,,,British Columbia
 CVR-0159107,Andy,Astronaut,1966-10-08,Asymptomatic,2020-05-18,2020-06-01,,1 Autumn Leaf Hill,Surrey,N7Z2D4,923-238-3948,,,qwerty@facebook.ty,Land border,Aldergrove,,,,British Columbia
-CVR-0159108,Tedd,Thompson,1962-02-12,Asymptomatic,2020-12-25,2021-01-08,,548 Ridge Oak Plaza,Courtenay,B6A4H6,,,543-286-7484,eklewi7o@nyu.edu,Land border,Douglas,,,,British Columbia
-CVR-0159109,Tedd,Thompson,1962-02-12,Asymptomatic,2020-12-25,2021-01-08,,548 Ridge Oak Plaza,Courtenay,B6A4H6,,,543-286-7484,eklewi7o@nyu.edu,Land border,Douglas,,,,British Columbia
+CVR-0159108,Tedd,Thompson,1962-02-12,Asymptomatic,2030-12-25,2021-01-08,,548 Ridge Oak Plaza,Courtenay,B6A4H6,,,543-286-7484,eklewi7o@nyu.edu,Land border,Douglas,,,,British Columbia
+CVR-0159109,Tedd,Thompson,1962-02-12,Asymptomatic,2030-12-25,2021-01-08,,548 Ridge Oak Plaza,Courtenay,B6A4H6,,,543-286-7484,eklewi7o@nyu.edu,Land border,Douglas,,,,British Columbia

--- a/server/tests/phac-ets-functions.test.js
+++ b/server/tests/phac-ets-functions.test.js
@@ -1,6 +1,7 @@
 const request = require('supertest');
 const { readFileSync } = require('fs');
 const { join } = require('path');
+const MockDate = require('mockdate');
 const app = require('../server');
 const { dbClient, collections, TEST_DB } = require('../db');
 const { startDB, closeDB } = require('./util/db');
@@ -60,6 +61,14 @@ describe('Test phac-servicebc queries and endpoints', () => {
     return formsCollection.insertMany(formattedEtsData);
   }
 
+  beforeEach(() => {
+    MockDate.set('2020-05-17');
+  });
+
+  afterEach(() => {
+    MockDate.reset();
+  });
+
   beforeAll(async () => {
     await startDB();
     server = app.listen();
@@ -103,7 +112,7 @@ describe('Test phac-servicebc queries and endpoints', () => {
     const etsCollection = dbClient.db.collection(collections.FORMS);
     const phacCollection = dbClient.db.collection(collections.PHAC);
     const duplicates = await markDuplicates(etsCollection, phacCollection);
-    expect(duplicates).toMatch(/^7 duplicates within ETS collection/gm);
+    expect(duplicates).toMatch(/^5 duplicates within ETS collection/gm);
     expect(duplicates).toMatch(/^1 duplicates within PHAC collection/gm);
     const transactions = await sendPhacToSBC(phacCollection);
     expect(transactions).toMatch(/^0 success\(es\)/gm);


### PR DESCRIPTION
This PR addresses both issues raised in the ticket:
- PHAC records with arrival dates two days in the past were not picked up by the PHAC-to-SBC script
- Old records in the PHAC collection were always considered for de-duplication (58 at time of writing)