### PR TITLE
chore: remove master branch deployment trigger

### DIFF
--- a/.github/workflows/ci_prod.yml
+++ b/.github/workflows/ci_prod.yml
@@ -1,9 +1,5 @@
 name: Build & Deploy
 
-on:
-  push:
-    branches: [master]
-
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We decided to move to tag based deployment. 

This means - We need to stop deploying to prod on merging to master. This PR does that. 