### PR TITLE
Revert "[ETS-407] Add TTL for production domain."

### DIFF
--- a/terraform/prod.tf
+++ b/terraform/prod.tf
@@ -15,7 +15,7 @@ resource "aws_route53_record" "www" {
   zone_id = aws_route53_zone.ets[0].zone_id
   name    = "travelscreening.gov.bc.ca"
   type    = "A"
-  ttl     = "300"
+
   alias {
     name                   = aws_cloudfront_distribution.app.domain_name
     zone_id                = aws_cloudfront_distribution.app.hosted_zone_id


### PR DESCRIPTION
Reverts bcgov/enhanced-travel-screening#181

Since 

```
Error: Conflicting configuration arguments

  on prod.tf line 18, in resource "aws_route53_record" "www":
  18:   ttl     = "300"

"ttl": conflicts with alias
```

 (Required for non-alias records) The TTL of the record.
 
 https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record